### PR TITLE
Fix error for module not found 

### DIFF
--- a/templates/commit-msg.txt
+++ b/templates/commit-msg.txt
@@ -1,3 +1,3 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-HUSKY_GIT_PARAMS=$1 node ../validate.js
+HUSKY_GIT_PARAMS=$1 node ./validate.js


### PR DESCRIPTION
While committing with the commit message formatter gives an error for Module not found